### PR TITLE
Update door state without reloading

### DIFF
--- a/EasyEntryApp-PWA/EasyEntryApp/DoorOpenerComponents/DoorControll.razor
+++ b/EasyEntryApp-PWA/EasyEntryApp/DoorOpenerComponents/DoorControll.razor
@@ -101,11 +101,10 @@
                 StopButtonPressed = false;
                 break;
         }
-        ReloadPage();
-    }
-    
-    private void ReloadPage()
-    {
-        navigationManager.NavigateTo(navigationManager.Uri, true);
+        var response = await Device.TestConnection(Device.DeviceURL);
+        deviceStatus = response.IsOnline;
+        isOpened = response.IsOpen;
+        Device.IsOpened = response.IsOpen;
+        StateHasChanged();
     }
 }


### PR DESCRIPTION
## Summary
- refresh device state inside `DisplayButtonPress`
- remove page reload and rely on `StateHasChanged`

## Testing
- `dotnet build EasyEntryApp-PWA/EasyEntryApp.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687901ef874c8327af85cda180e6bb34