### PR TITLE
Add routine management feature

### DIFF
--- a/EasyEntryApp-PWA/EasyEntryApi/Controllers/RoutineController.cs
+++ b/EasyEntryApp-PWA/EasyEntryApi/Controllers/RoutineController.cs
@@ -1,0 +1,82 @@
+using doorOpener.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace EasyEntryApi.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class RoutineController : ControllerBase
+{
+    private readonly AppDbContext _context;
+
+    public RoutineController(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<Routine>>> GetAll()
+    {
+        return await _context.Routines
+            .Include(r => r.Steps)
+            .ToListAsync();
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<Routine>> GetById(int id)
+    {
+        var routine = await _context.Routines
+            .Include(r => r.Steps)
+            .FirstOrDefaultAsync(r => r.Id == id);
+
+        if (routine == null)
+            return NotFound();
+
+        return routine;
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<Routine>> CreateRoutine(Routine routine)
+    {
+        _context.Routines.Add(routine);
+        await _context.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetById), new { id = routine.Id }, routine);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> UpdateRoutine(int id, Routine routine)
+    {
+        if (id != routine.Id)
+            return BadRequest();
+
+        var existing = await _context.Routines
+            .Include(r => r.Steps)
+            .FirstOrDefaultAsync(r => r.Id == id);
+        if (existing == null)
+            return NotFound();
+
+        existing.Name = routine.Name;
+        _context.RoutineSteps.RemoveRange(existing.Steps);
+        existing.Steps = routine.Steps;
+
+        await _context.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteRoutine(int id)
+    {
+        var routine = await _context.Routines
+            .Include(r => r.Steps)
+            .FirstOrDefaultAsync(r => r.Id == id);
+
+        if (routine == null)
+            return NotFound();
+
+        _context.Routines.Remove(routine);
+        await _context.SaveChangesAsync();
+        return NoContent();
+    }
+}
+

--- a/EasyEntryApp-PWA/EasyEntryApi/DBContext.cs
+++ b/EasyEntryApp-PWA/EasyEntryApi/DBContext.cs
@@ -10,6 +10,8 @@ public class AppDbContext : DbContext
     public DbSet<Device> Devices => Set<Device>();
     public DbSet<Setting> Settings => Set<Setting>();
     public DbSet<DeviceGroup> DeviceGroups => Set<DeviceGroup>();
+    public DbSet<Routine> Routines => Set<Routine>();
+    public DbSet<RoutineStep> RoutineSteps => Set<RoutineStep>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -17,6 +19,12 @@ public class AppDbContext : DbContext
             .HasMany(g => g.Devices)
             .WithOne(d => d.DeviceGroup!)
             .HasForeignKey(d => d.DeviceGroupId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<Routine>()
+            .HasMany(r => r.Steps)
+            .WithOne(s => s.Routine!)
+            .HasForeignKey(s => s.RoutineId)
             .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/EasyEntryApp-PWA/EasyEntryApi/Migrations/20250717210100_AddRoutineTables.cs
+++ b/EasyEntryApp-PWA/EasyEntryApi/Migrations/20250717210100_AddRoutineTables.cs
@@ -1,0 +1,80 @@
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EasyEntryApi.Migrations;
+
+/// <inheritdoc />
+public partial class AddRoutineTables : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "Routines",
+            columns: table => new
+            {
+                Id = table.Column<int>(type: "int", nullable: false)
+                    .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                Name = table.Column<string>(type: "longtext", nullable: false)
+                    .Annotation("MySql:CharSet", "utf8mb4")
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Routines", x => x.Id);
+            })
+            .Annotation("MySql:CharSet", "utf8mb4");
+
+        migrationBuilder.CreateTable(
+            name: "RoutineSteps",
+            columns: table => new
+            {
+                Id = table.Column<int>(type: "int", nullable: false)
+                    .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                Order = table.Column<int>(type: "int", nullable: false),
+                StepType = table.Column<int>(type: "int", nullable: false),
+                DeviceId = table.Column<int>(type: "int", nullable: true),
+                Action = table.Column<int>(type: "int", nullable: true),
+                DurationSeconds = table.Column<int>(type: "int", nullable: false),
+                RoutineId = table.Column<int>(type: "int", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_RoutineSteps", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_RoutineSteps_Devices_DeviceId",
+                    column: x => x.DeviceId,
+                    principalTable: "Devices",
+                    principalColumn: "Id");
+                table.ForeignKey(
+                    name: "FK_RoutineSteps_Routines_RoutineId",
+                    column: x => x.RoutineId,
+                    principalTable: "Routines",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            })
+            .Annotation("MySql:CharSet", "utf8mb4");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_RoutineSteps_DeviceId",
+            table: "RoutineSteps",
+            column: "DeviceId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_RoutineSteps_RoutineId",
+            table: "RoutineSteps",
+            column: "RoutineId");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "RoutineSteps");
+
+        migrationBuilder.DropTable(
+            name: "Routines");
+    }
+}
+

--- a/EasyEntryApp-PWA/EasyEntryApi/Migrations/AppDbContextModelSnapshot.cs
+++ b/EasyEntryApp-PWA/EasyEntryApi/Migrations/AppDbContextModelSnapshot.cs
@@ -101,6 +101,80 @@ namespace EasyEntryApi.Migrations
                 {
                     b.Navigation("Devices");
                 });
+
+            modelBuilder.Entity("doorOpener.Models.Routine", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasColumnType("longtext");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Routines");
+                });
+
+            modelBuilder.Entity("doorOpener.Models.RoutineStep", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<int?>("Action")
+                        .HasColumnType("int");
+
+                    b.Property<int?>("DeviceId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("DurationSeconds")
+                        .HasColumnType("int");
+
+                    b.Property<int>("Order")
+                        .HasColumnType("int");
+
+                    b.Property<int>("RoutineId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("StepType")
+                        .HasColumnType("int");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("DeviceId");
+
+                    b.HasIndex("RoutineId");
+
+                    b.ToTable("RoutineSteps");
+                });
+
+            modelBuilder.Entity("doorOpener.Models.RoutineStep", b =>
+                {
+                    b.HasOne("doorOpener.Models.Device", "Device")
+                        .WithMany()
+                        .HasForeignKey("DeviceId");
+
+                    b.HasOne("doorOpener.Models.Routine", "Routine")
+                        .WithMany("Steps")
+                        .HasForeignKey("RoutineId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Device");
+
+                    b.Navigation("Routine");
+                });
+
+            modelBuilder.Entity("doorOpener.Models.Routine", b =>
+                {
+                    b.Navigation("Steps");
+                });
 #pragma warning restore 612, 618
         }
     }

--- a/EasyEntryApp-PWA/EasyEntryApp/Dialogs/AddRoutineDialog.razor
+++ b/EasyEntryApp-PWA/EasyEntryApp/Dialogs/AddRoutineDialog.razor
@@ -1,0 +1,93 @@
+@using doorOpener.Models
+@using EasyEntryLib.Services
+@inject ISnackbar Snackbar
+@inject RoutineService RoutineService
+@inject DeviceGroupService DeviceGroupService
+
+<MudDialog>
+    <TitleContent>
+        Routine erstellen
+    </TitleContent>
+    <DialogContent>
+        <MudForm>
+            <MudTextField @bind-Value="routineName" Label="Name" />
+            <MudDivider Class="my-2" />
+            <MudStack>
+                @foreach(var step in Steps)
+                {
+                    <MudPaper Class="pa-2 ma-2">
+                        <MudSelect T="StepType" Label="Typ" @bind-Value="step.StepType" />
+                        @if(step.StepType == StepType.DeviceAction)
+                        {
+                            <MudSelect T="int" Label="Gerät" @bind-Value="step.DeviceId">
+                                @foreach(var d in AllDevices)
+                                {
+                                    <MudSelectItem T="int" Value="@d.Id">@d.Name</MudSelectItem>
+                                }
+                            </MudSelect>
+                            <MudSelect T="DeviceStatus" Label="Aktion" @bind-Value="step.Action">
+                                <MudSelectItem Value="DeviceStatus.Opened">Öffnen</MudSelectItem>
+                                <MudSelectItem Value="DeviceStatus.Neutral">Stopp</MudSelectItem>
+                                <MudSelectItem Value="DeviceStatus.Closed">Schließen</MudSelectItem>
+                            </MudSelect>
+                        }
+                        @if(step.StepType == StepType.Delay)
+                        {
+                            <MudNumericField T="int" Label="Wartezeit (s)" @bind-Value="step.DurationSeconds" />
+                        }
+                    </MudPaper>
+                }
+                <MudButton Variant="Variant.Outlined" OnClick="AddStep">Schritt hinzufügen</MudButton>
+            </MudStack>
+        </MudForm>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Abbrechen</MudButton>
+        <MudButton Color="Color.Primary" OnClick="SaveRoutine">Speichern</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter]
+    private IMudDialogInstance MudDialog { get; set; } = default!;
+
+    private string routineName = string.Empty;
+    private List<Device> AllDevices = new();
+    private List<RoutineStep> Steps = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        var groups = await DeviceGroupService.GetAllAsync();
+        AllDevices = groups.SelectMany(g => g.Devices).ToList();
+        AddStep();
+    }
+
+    private void AddStep()
+    {
+        Steps.Add(new RoutineStep{ StepType = StepType.DeviceAction });
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private async Task SaveRoutine()
+    {
+        if(string.IsNullOrWhiteSpace(routineName))
+        {
+            Snackbar.Add("Name darf nicht leer sein", Severity.Error);
+            return;
+        }
+
+        var routine = new Routine { Name = routineName, Steps = Steps };
+        var success = await RoutineService.CreateAsync(routine);
+        if(success)
+        {
+            Snackbar.Add("Routine gespeichert", Severity.Success);
+            MudDialog.Close(DialogResult.Ok(true));
+        }
+        else
+        {
+            Snackbar.Add("Fehler beim Speichern", Severity.Error);
+        }
+    }
+}
+

--- a/EasyEntryApp-PWA/EasyEntryApp/Layout/MainLayout.razor
+++ b/EasyEntryApp-PWA/EasyEntryApp/Layout/MainLayout.razor
@@ -28,6 +28,7 @@
         <MudNavMenu>
             <MudNavLink Icon="@Icons.Material.Filled.SpaceDashboard" IconColor="Color.Primary" Href="" Match="NavLinkMatch.All">Dashboard</MudNavLink>
             <MudNavLink Icon="@Icons.Material.Filled.BackupTable" IconColor="Color.Primary" Href="/groupmanagement" Match="NavLinkMatch.Prefix">Gruppen Verwalten</MudNavLink>
+            <MudNavLink Icon="@Icons.Material.Filled.PlaylistAdd" IconColor="Color.Primary" Href="/routines" Match="NavLinkMatch.Prefix">Routinen</MudNavLink>
         </MudNavMenu>
     </MudDrawer>
 </MudLayout>
@@ -118,6 +119,8 @@
                 return "Dashboard";
             case "groupmanagement":
                 return "Gruppen Management";
+            case "routines":
+                return "Routinen";
             default: return "Dashboard";
         }
     }

--- a/EasyEntryApp-PWA/EasyEntryApp/Pages/RoutineManagement.razor
+++ b/EasyEntryApp-PWA/EasyEntryApp/Pages/RoutineManagement.razor
@@ -1,0 +1,49 @@
+@page "/routines"
+@using doorOpener.Models
+@using EasyEntryApp.Dialogs
+@using EasyEntryLib.Services
+@inject IDialogService DialogService
+@inject RoutineService RoutineService
+@inject NavigationManager navigationManager
+
+<MudStack Row="true">
+    <MudSpacer></MudSpacer>
+    <MudIconButton Class="mr-8" Edge="Edge.End" Icon="@Icons.Material.Filled.AddCircle" OnClick="OpenAddRoutineDialog"></MudIconButton>
+</MudStack>
+
+<MudPaper Class="pa-4 ma-4">
+    <MudList>
+        @foreach (var routine in Routines)
+        {
+            <MudListItem>@routine.Name</MudListItem>
+        }
+    </MudList>
+</MudPaper>
+
+@code {
+    List<Routine> Routines = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        Routines = await RoutineService.GetAllAsync();
+    }
+
+    private async Task OpenAddRoutineDialog()
+    {
+        var options = new DialogOptions()
+        {
+            BackdropClick = false,
+            CloseButton = false,
+            MaxWidth = MaxWidth.Medium,
+            FullWidth = true
+        };
+
+        var reference = await DialogService.ShowAsync<AddRoutineDialog>("Routine erstellen", options);
+        var result = await reference.Result;
+        if (result.Data is bool isCancelled && isCancelled)
+        {
+            navigationManager.NavigateTo(navigationManager.Uri, true);
+        }
+    }
+}
+

--- a/EasyEntryApp-PWA/EasyEntryApp/Program.cs
+++ b/EasyEntryApp-PWA/EasyEntryApp/Program.cs
@@ -12,5 +12,6 @@ builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(Environm
 builder.Services.AddScoped<SettingService>();
 builder.Services.AddScoped<DeviceGroupService>();
 builder.Services.AddScoped<DeviceService>();
+builder.Services.AddScoped<RoutineService>();
 
 await builder.Build().RunAsync();

--- a/EasyEntryApp-PWA/EasyEntryLib/Models/Routine.cs
+++ b/EasyEntryApp-PWA/EasyEntryLib/Models/Routine.cs
@@ -1,0 +1,28 @@
+namespace doorOpener.Models;
+
+public enum StepType
+{
+    DeviceAction = 1,
+    Delay = 2
+}
+
+public class Routine
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public List<RoutineStep> Steps { get; set; } = new();
+}
+
+public class RoutineStep
+{
+    public int Id { get; set; }
+    public int Order { get; set; }
+    public StepType StepType { get; set; }
+    public int? DeviceId { get; set; }
+    public Device? Device { get; set; }
+    public DeviceStatus? Action { get; set; }
+    public int DurationSeconds { get; set; }
+    public int RoutineId { get; set; }
+    public Routine? Routine { get; set; }
+}
+

--- a/EasyEntryApp-PWA/EasyEntryLib/Services/RoutineService.cs
+++ b/EasyEntryApp-PWA/EasyEntryLib/Services/RoutineService.cs
@@ -1,0 +1,92 @@
+using doorOpener.Models;
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+
+namespace EasyEntryLib.Services;
+
+public class RoutineService
+{
+    private readonly HttpClient _http;
+    private readonly ILogger<RoutineService> _logger;
+
+    public RoutineService(HttpClient http, ILogger<RoutineService> logger)
+    {
+        _http = http;
+        _logger = logger;
+    }
+
+    public async Task<List<Routine>> GetAllAsync()
+    {
+        try
+        {
+            return await _http.GetFromJsonAsync<List<Routine>>("api/routine") ?? new();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Fehler beim Abrufen aller Routinen");
+            return new();
+        }
+    }
+
+    public async Task<Routine?> GetByIdAsync(int id)
+    {
+        try
+        {
+            var response = await _http.GetAsync($"api/routine/{id}");
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Routine mit ID {Id} nicht gefunden. Status: {Status}", id, response.StatusCode);
+                return null;
+            }
+            return await response.Content.ReadFromJsonAsync<Routine>();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Fehler beim Abrufen der Routine ID {Id}", id);
+            return null;
+        }
+    }
+
+    public async Task<bool> CreateAsync(Routine routine)
+    {
+        try
+        {
+            var response = await _http.PostAsJsonAsync("api/routine", routine);
+            return response.IsSuccessStatusCode;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Fehler beim Erstellen einer Routine");
+            return false;
+        }
+    }
+
+    public async Task<bool> UpdateAsync(Routine routine)
+    {
+        try
+        {
+            var response = await _http.PutAsJsonAsync($"api/routine/{routine.Id}", routine);
+            return response.IsSuccessStatusCode;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Fehler beim Aktualisieren der Routine ID {Id}", routine.Id);
+            return false;
+        }
+    }
+
+    public async Task<bool> DeleteAsync(int id)
+    {
+        try
+        {
+            var response = await _http.DeleteAsync($"api/routine/{id}");
+            return response.IsSuccessStatusCode;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Fehler beim Löschen der Routine ID {Id}", id);
+            return false;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add new Routine and RoutineStep models
- support CRUD for routines via RoutineService and RoutineController
- update DB context and migrations for routines
- include routine creation dialog and management page
- register RoutineService and navigation entry

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687a09ead14c8327a5e5802846358aeb